### PR TITLE
Filename loader

### DIFF
--- a/osprey/config.py
+++ b/osprey/config.py
@@ -30,7 +30,7 @@ from six.moves import reduce
 from pkg_resources import resource_filename
 
 from .entry_point import load_entry_point
-from .utils import dict_merge, in_directory
+from .utils import dict_merge, in_directory, prepend_syspath
 from .search_space import SearchSpace
 from .strategies import BaseStrategy
 from .dataset_loaders import BaseDatasetLoader
@@ -194,12 +194,13 @@ class Config(object):
         # load estimator from pickle field
         pkl = self.get_value('estimator/pickle')
         if pkl is not None:
-            path = join(dirname(abspath(self.path)), pkl)
+            pickl_dir = dirname(abspath(self.path))
+            path = join(pickl_dir, pkl)
             if not isfile(path):
                 raise RuntimeError('estimator/pickle %s is not a file' % pkl)
-            sys.path.insert(0, dirname(abspath(self.path)))
             with open(path, 'rb') as f:
-                estimator = cPickle.load(f)
+                with prepend_syspath(pickl_dir):
+                    estimator = cPickle.load(f)
                 if not isinstance(estimator, sklearn.base.BaseEstimator):
                     raise RuntimeError('estimator/pickle must load a '
                                        'sklearn-derived Estimator')

--- a/osprey/dataset_loaders.py
+++ b/osprey/dataset_loaders.py
@@ -48,4 +48,3 @@ class FilenameDatasetLoader(BaseDatasetLoader):
         if self.abs_path:
             filenames = [os.path.abspath(fn) for fn in filenames]
         return filenames, None
-

--- a/osprey/utils.py
+++ b/osprey/utils.py
@@ -1,5 +1,6 @@
 from __future__ import print_function, absolute_import, division
 import os.path
+import sys
 import contextlib
 from datetime import datetime
 
@@ -34,6 +35,14 @@ def in_directory(path):
     os.chdir(path)
     yield
     os.chdir(curdir)
+
+
+@contextlib.contextmanager
+def prepend_syspath(path):
+    """Contect manager (with statement) that prepends path to sys.path"""
+    sys.path.insert(0, path)
+    yield
+    sys.path.pop(0)
 
 
 class Unbuffered(object):


### PR DESCRIPTION
For when mdtraj just doesn't cut it :)

also added the current directory to sys.path when loading the estimator from a pickle file. This lets you define a new estimator in a module in your run directory
