### PR TITLE
Changes to MOE defaults

### DIFF
--- a/osprey/strategies.py
+++ b/osprey/strategies.py
@@ -172,7 +172,7 @@ class HyperoptTPE(BaseStrategy):
 class MOE(BaseStrategy):
     short_name = 'moe'
 
-    def __init__(self, url=None, noise_variance=0.1, method='kriging',
+    def __init__(self, url=None, noise_variance=0.1, method='constant_liar',
                  lie_method='constant_liar_min'):
         self.url = url
         self.noise_variance = noise_variance


### PR DESCRIPTION
This changes the default MOE endpoint. The difference comes when you have >0 experiments in the PENDING state, and it affects what guesses MOE makes about how those experiments are going to turn on when it recommends the next point. Once I understand the tradeoffs between the methods better, I will add some explanation to the docstrings.

cc: https://github.com/Yelp/MOE/issues/420
