### PR TITLE
Add estimator/params to config

### DIFF
--- a/osprey/config.py
+++ b/osprey/config.py
@@ -42,7 +42,8 @@ from . import eval_scopes
 
 
 FIELDS = {
-    'estimator':       ['pickle', 'eval', 'eval_scope', 'entry_point'],
+    'estimator':       ['pickle', 'eval', 'eval_scope', 'entry_point',
+                        'params'],
     'dataset_loader':  ['name', 'params'],
     'trials':          ['uri', 'project_name'],
     'search_space':    dict,

--- a/osprey/tests/test_config.py
+++ b/osprey/tests/test_config.py
@@ -54,6 +54,19 @@ def test_estimator_entry_point():
     assert isinstance(config.estimator(), KMeans)
 
 
+def test_estimator_entry_point_params():
+    config = Config.fromdict({
+        'estimator': {
+            'entry_point': 'sklearn.cluster.KMeans',
+            'params': {
+                'n_clusters': 15
+            }
+        }
+    }, check_fields=False)
+    assert isinstance(config.estimator(), KMeans)
+    assert config.estimator().n_clusters == 15
+
+
 def test_search_space():
     config = Config.fromdict({
         'search_space': {


### PR DESCRIPTION
Add kwargs to `entry_point` instantiation process. This gives me extra flexibility that I will need to write an sklearn wrapper for pylearn2, where some parameters will not be set in `fit_and_score_estimator`, while minimally changing the existing interface (e.g. I could add `estimator/pylearn2` to config, but that seems messier than writing a pylearn2 `entry_point`).
