### PR TITLE
Fix error due to trajectories not having a `shape` attribute

### DIFF
--- a/osprey/execute_worker.py
+++ b/osprey/execute_worker.py
@@ -13,6 +13,7 @@ from six import iteritems
 from six.moves import cStringIO
 from sqlalchemy import func
 from sklearn.base import clone, BaseEstimator
+import numpy as np
 
 from . import __version__
 from .config import Config
@@ -43,7 +44,10 @@ def execute(args, parser):
     print('Dataset contains %d element(s) with %s labels'
           % (len(X), 'out' if y is None else ''))
     print('The elements have shape: [%s' %
-          ', '.join([str(X[i].shape) for i in range(min(len(X), 20))]), end='')
+          ', '.join([str(X[i].shape)
+                     if isinstance(X[i], (np.ndarray, np.generic))
+                     else '(%s,)' % len(X[i])
+                     for i in range(min(len(X), 20))]), end='')
     print(', ...]' if (len(X) > 20) else ']')
     print('Instantiated estimator:')
     print('  %r' % estimator)


### PR DESCRIPTION
This fixes a bug introduced in https://github.com/msmbuilder/osprey/commit/4048c930b03fb58b7574baddcbe2ee8eefbf76c4, which would throw an `AttributeError: 'Trajectory' object has no attribute 'shape'` when using the `mdtraj` dataset loader.