### PR TITLE
add nancheck for scores

### DIFF
--- a/osprey/fit_estimator.py
+++ b/osprey/fit_estimator.py
@@ -68,6 +68,11 @@ def fit_and_score_estimator(estimator, parameters, cv, X, y=None, scoring=None,
         n_test_samples.append(n_test)
         n_train_samples.append(n_train)
 
+    train_scores, test_scores = map(list, check_arrays(train_scores,
+                                                       test_scores,
+                                                       warn_nans=True,
+                                                       replace_nans=True))
+
     if iid:
         if verbose > 0 and is_msmbuilder_estimator(estimator):
             print('[CV] Using MSMBuilder API n_samples averaging')


### PR DESCRIPTION
re: https://github.com/msmbuilder/osprey/issues/73, https://github.com/msmbuilder/osprey/issues/75

This PR extends the functionality of `check_arrays`, adding flags for `warn_nans` and `replace_nans`. If set, these flags will check the array for non-finite values, triggering a `UserWarning` if one is found, and replace these values according to `np.nan_to_num`, respectively.

I've also added a nancheck for train and test scores in `fit_estimator.py`, which makes use of `warn_nans` and `replace_nans`. This will set any `nan` scores to zero and allow osprey to handle these values more gracefully. 

An alternative to this could be to flag trials with `nans` as `FAILED` and move on.

LMKWYT