### PR TITLE
current_best now reports weighted standard deviation

### DIFF
--- a/osprey/execute_currentbest.py
+++ b/osprey/execute_currentbest.py
@@ -28,11 +28,6 @@ def execute(args, parser):
         print('~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~')
         print('Best Current Model = %f +- %f' % (weighted_mean,
                                                  weighted_std))
-
-
-        print('~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~')
-        print('Best Current Model = %f +- %f' % (c_b_m["mean_test_score"],
-                                                 np.std(c_b_m["test_scores"])))
         print('~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~')
         if isinstance(config.estimator(), Pipeline):
             print('PipelineStep\tParamter \t Value')

--- a/osprey/execute_currentbest.py
+++ b/osprey/execute_currentbest.py
@@ -20,6 +20,16 @@ def execute(args, parser):
                                                   dtype=float))
         c_b_m = items[mean_test_scores.argmax()]
         parameter_dict = c_b_m["parameters"]
+        weighted_mean = c_b_m["mean_test_score"]
+        raw_test_scores = np.array(c_b_m["test_scores"])
+        raw_test_weights = np.array(c_b_m["n_test_samples"])
+        weighted_var = np.average((raw_test_scores - weighted_mean)**2, weights=raw_test_weights)
+        weighted_std = np.sqrt(weighted_var)
+        print('~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~')
+        print('Best Current Model = %f +- %f' % (weighted_mean,
+                                                 weighted_std))
+
+
         print('~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~')
         print('Best Current Model = %f +- %f' % (c_b_m["mean_test_score"],
                                                  np.std(c_b_m["test_scores"])))


### PR DESCRIPTION
The average test score reported from osprey is weighted by the number of samples used for testing. This PR now has the current_best command reporting a weighted standard deviation instead of an unweighted one.