### PR TITLE
Improve json dump behaviour

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -14,6 +14,8 @@ API Changes
 New Features
 ~~~~~~~~~~~~
 + Added support for ``TimeSeriesSplit`` and ``LeavePOut`` cross-validators.
++ Improved ``osprey dump`` JSON output. The hyperparameters for each run are now stored along all
+the other settings in the same dictionary, allowing for subsequent easier loading and plotting.
 
 Bug Fixes
 ~~~~~~~~~

--- a/osprey/execute_dump.py
+++ b/osprey/execute_dump.py
@@ -15,7 +15,14 @@ def execute(args, parser):
 
     if args.output == 'json':
         items = [curr.to_dict() for curr in session.query(Trial).all()]
-        value = json.dumps(items)
+        new_items = []
+        # Instead of saving the parameters on their own nested dict,
+        # save them along the rest of elements
+        for item in items:
+            parameters = item.pop('parameters')  # remove dict
+            item.update(parameters)  # update original dict with the parameters
+            new_items.append(item)
+        value = json.dumps(new_items)
 
     elif args.output == 'csv':
         buf = cStringIO()


### PR DESCRIPTION
Here's my attempt to fix my [suggestion](https://github.com/msmbuilder/osprey/issues/207) from some days ago.

 - [x] Implement feature / fix bug
 - [ ] Add tests
 - [x] Update changelog

I noticed the hyperparameters were being saved in their own dictionary inside the dictionary with all the other settings. Now they get stored along the rest of the settings for the run.

Let me know if this is along the lines you had in mind. Also, this might now break quite a lot of plotting functions that might be expecting the hyperparameters to be in the `parameters` column.

Referring back to my issue, this new behaviour now permits doing something much less involved, like so:
```python
%pylab inline
import pandas as pd
df = pd.read_json('dump.json')
plt.scatter(df['tica__lag_time'], df['mean_test_score'])
```
![test](https://cloud.githubusercontent.com/assets/10696140/23276374/e8e4350a-fa01-11e6-8be9-de399e8c4a82.png)

