### PR TITLE
Skip re-running a trial with identical params 

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -15,7 +15,11 @@ New Features
 ~~~~~~~~~~~~
 + Added support for ``TimeSeriesSplit`` and ``LeavePOut`` cross-validators.
 + Improved ``osprey dump`` JSON output. The hyperparameters for each run are now stored along all
-the other settings in the same dictionary, allowing for subsequent easier loading and plotting.
+  the other settings in the same dictionary, allowing for subsequent easier loading and plotting.
++ Added ``max_param_suggestion_retries`` entry to the config file. This limits the number of times that
+  ``strategy.suggest`` is called when attempting to produce a trial with a set of params not previously
+  tested in the history. 
+
 
 Bug Fixes
 ~~~~~~~~~

--- a/docs/config_file.rst
+++ b/docs/config_file.rst
@@ -220,6 +220,20 @@ recommended when scaling across multiple jobs. However, a workaround
 would be to create multiple copies of the configuration file, each
 with a unique random seed, for each independent worker to run.
 
+
+Max Parameter Suggestion Retries
+--------------------------------
+By default Osprey will create trials that were previously tested. This can
+occur for example when restarting a grid search. By setting the optional
+``max_param_suggestion_retries`` parameter, Osprey will exit if it fails to 
+generate a parameter set that is not already in the database after
+``max_param_suggestion_retries`` attempts.
+
+Example: ::
+
+   max_param_suggestion_retries: 10
+
+
 Trials Storage
 --------------
 

--- a/osprey/config.py
+++ b/osprey/config.py
@@ -53,6 +53,7 @@ FIELDS = {
     'cv':              (int, dict),
     'scoring':         (str, type(None)),
     'random_seed':     (int, type(None)),
+    'max_param_suggestion_retries': (int, type(None)),
 }
 
 
@@ -110,7 +111,7 @@ class Config(object):
         missing_fields = set(FIELDS.keys()).difference(self.config.keys())
         if len(missing_fields) > 0:
             raise RuntimeError('The following required fields are missing from'
-                               'the config file (%s): %s' % (
+                               ' the config file (%s): %s' % (
                                    ', '.join(missing_fields), self.path))
 
     @classmethod
@@ -338,6 +339,11 @@ class Config(object):
         random_seed = self.get_section('random_seed')
         assert isinstance(random_seed, (int, type(None)))
         return random_seed
+
+    def max_param_suggestion_retries(self):
+        max_param_suggestion_retries = self.get_section('max_param_suggestion_retries')
+        assert isinstance(max_param_suggestion_retries, (int, type(None)))
+        return max_param_suggestion_retries
 
     def cv(self, X, y=None):
         cv = self.get_section('cv')

--- a/osprey/data/default_config.yaml
+++ b/osprey/data/default_config.yaml
@@ -4,3 +4,5 @@ trials:
 scoring: !!null
 
 random_seed: !!null
+
+max_param_suggestion_retries: !!null

--- a/osprey/strategies.py
+++ b/osprey/strategies.py
@@ -51,6 +51,27 @@ class BaseStrategy(object):
         """
         raise NotImplementedError()
 
+    @staticmethod
+    def is_repeated_suggestion(params, history):
+        """
+        Parameters
+        ----------
+        params : dict
+            Trial param set
+        history : list of 3-tuples
+            History of past function evaluations. Each element in history
+            should be a tuple `(params, score, status)`, where `params` is a
+            dict mapping parameter names to values
+
+        Returns
+        -------
+        is_repeated_suggestion : bool
+        """
+        if any(params == hparams and hstatus == 'SUCCEEDED' for hparams, hscore, hstatus in history):
+            return True
+        else:
+            return False
+
 
 class RandomSearch(BaseStrategy):
     short_name = 'random'

--- a/osprey/tests/test_strategies.py
+++ b/osprey/tests/test_strategies.py
@@ -32,6 +32,34 @@ def test_grid():
     assert suggestions == [(1, 3), (1, 4), (2, 3), (2, 4)], "Didn't examine whole space correctly"
 
 
+def test_check_repeated_params():
+    searchspace = SearchSpace()
+    searchspace.add_enum('x', [1, 2])
+    searchspace.add_jump('y', min=3, max=4, num=2)
+
+    history = []
+    grid_search1 = GridSearch()
+    for _ in range(4):
+        params = grid_search1.suggest(history, searchspace)
+        history.append((params, 0.0, 'SUCCEEDED'))
+
+    grid_search2 = GridSearch()
+    for _ in range(4):
+        params = grid_search2.suggest(history, searchspace)
+        assert grid_search2.is_repeated_suggestion(params, history)
+
+    history = []
+    grid_search3 = GridSearch()
+    for _ in range(4):
+        params = grid_search3.suggest(history, searchspace)
+        history.append((params, 0.0, 'FAILED'))
+
+    grid_search4 = GridSearch()
+    for _ in range(4):
+        params = grid_search4.suggest(history, searchspace)
+        assert not grid_search4.is_repeated_suggestion(params, history)
+
+
 def hyperopt_x2_iterates(n_iters=100):
     iterates = []
     trials = Trials()


### PR DESCRIPTION
 - [x] Implement feature / fix bug
 - [x] Add tests
 - [ ] Update changelog

This implements a change to the worker so it does not repeat trials on identical parameter sets as suggested in https://github.com/msmbuilder/osprey/issues/149. I've added a parameter to the config `max_param_suggestion_retries` which sets a limit on how many times `strategy.suggest` is called when it produces a new param set that already is in the history. The default is to create a trial ignoring previous history. 

This seems particularly helpful when restarting a run that uses a grid search so you don't re-calculate for already visited points on the grid. It may, however be better to do the check internal to the grid search's `suggest` method to "fast-forward" to the first point that hasn't already been visited. The current method only runs unique param combinations even when the search space has added or removed hyperparameters that aren't visible to `suggest`. 

This was my first stab at this and I didn't consult with the Osprey developers first, so I'm not sure if it is the preferred strategy for doing this. I'd appreciate any feedback/code review and I'd be happy to make any changes necessary to get it merged. 