### PR TITLE
Jump variable casting

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -24,6 +24,8 @@ New Features
 Bug Fixes
 ~~~~~~~~~
 
++ Fixed crashes when using ``jump`` variables of type ``int``.
+
 
 v1.1.0
 ------

--- a/osprey/data/grid_example.yaml
+++ b/osprey/data/grid_example.yaml
@@ -1,5 +1,7 @@
 estimator:
   entry_point: sklearn.svm.SVC
+  params:
+    kernel: poly
 
 strategy:
   name: grid
@@ -19,6 +21,13 @@ search_space:
     warp: log
     var_type: float
     type: jump
+
+  degree:
+     min: 1
+     max: 5
+     num: 5
+     var_type: int
+     type: jump
 
 cv: 5
 

--- a/osprey/search_space.py
+++ b/osprey/search_space.py
@@ -59,7 +59,7 @@ class SearchSpace(object):
             raise ValueError('variable %s: warp=%s is not supported. use '
                              'None or "log",' % (name, warp))
 
-        self.variables[name] = EnumVariable(name, list(choices))
+        self.variables[name] = EnumVariable(name, choices.tolist())
 
     def add_int(self, name, min, max, warp=None):
         """An integer-valued dimension bounded between `min` <= x <= `max`.


### PR DESCRIPTION
 - [x] Implement feature / fix bug
 - [x] Add tests
 - [x] Update changelog

Changed the casting of jump variables so that they are cast to native python types (i.e. floats and ints).  The problem was `list(choices)` keeps the types in the list intact and only changes the container to a python list.  `choices.tolist()` changes the container AND the datatypes to native python types.  
