### PR TITLE
New gp kernels

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -18,7 +18,8 @@ New Features
   the other settings in the same dictionary, allowing for subsequent easier loading and plotting.
 + Added ``max_param_suggestion_retries`` entry to the config file. This limits the number of times that
   ``strategy.suggest`` is called when attempting to produce a trial with a set of params not previously
-  tested in the history. 
+  tested in the history.
++ Added ability to specifiy arbitrary kernels for gaussian process strategy.
 
 
 Bug Fixes

--- a/osprey/config.py
+++ b/osprey/config.py
@@ -276,19 +276,23 @@ class Config(object):
         strategy_params = self.get_value('strategy/params', default={})
 
         if strategy_name == 'gp':
+            # TODO there must be a better place to put all this.
             # Default values
             try:
                 strategy_params['kernels']
             except KeyError:
-                strategy_params['kernels'] = [['GPy.kern.Matern52', {'ARD': True}, {'independent': False}]]
+                strategy_params['kernels'] = [{'name': 'GPy.kern.Matern52',
+                                               'kwargs': {'ARD': True},
+                                               'options': {'independent': False}}]
 
             # Check entries are of correct form
             kernels = strategy_params['kernels']
             if not isinstance(kernels, list):
                 raise RuntimeError('Must provide enumeration of Kernels')
             for kernel in kernels:
-                if not isinstance(kernel, list) or len(kernel) != 3:
-                    raise RuntimeError('Each kernel must be list: [entry point, {kwargs}, {options}]')
+                if not isinstance(kernel, dict) or len(kernel) != 3:
+                    raise RuntimeError("Each kernel must be dict: { 'name':  entry point, "
+                                       "kwargs : {kwargs}, options : {options} }")
 
         strat = init_subclass_by_name(BaseStrategy, strategy_name,
                                       strategy_params)

--- a/osprey/config.py
+++ b/osprey/config.py
@@ -276,23 +276,22 @@ class Config(object):
         strategy_params = self.get_value('strategy/params', default={})
 
         if strategy_name == 'gp':
-            # TODO there must be a better place to put all this.
+            # TODO there must be a better way to do conditional defaults.
             # Default values
             try:
                 strategy_params['kernels']
             except KeyError:
                 strategy_params['kernels'] = [{'name': 'GPy.kern.Matern52',
-                                               'kwargs': {'ARD': True},
+                                               'params': {'ARD': True},
                                                'options': {'independent': False}}]
-
             # Check entries are of correct form
             kernels = strategy_params['kernels']
             if not isinstance(kernels, list):
-                raise RuntimeError('Must provide enumeration of Kernels')
+                raise RuntimeError('Must provide enumeration of kernels')
             for kernel in kernels:
-                if not isinstance(kernel, dict) or len(kernel) != 3:
-                    raise RuntimeError("Each kernel must be dict: { 'name':  entry point, "
-                                       "kwargs : {kwargs}, options : {options} }")
+                if sorted(list(kernel.keys())) != ['name', 'options', 'params']:
+                    raise RuntimeError(
+                        'strategy/params/kernels must contain keys: "name", "options", "params"')
 
         strat = init_subclass_by_name(BaseStrategy, strategy_name,
                                       strategy_params)

--- a/osprey/config.py
+++ b/osprey/config.py
@@ -275,19 +275,20 @@ class Config(object):
         strategy_name = self.get_value('strategy/name')
         strategy_params = self.get_value('strategy/params', default={})
 
-        # Default values
-        try:
-            strategy_params['kernels']
-        except KeyError:
-            strategy_params['kernels'] = [['GPy.kern.Matern52', {'ARD': True}, {'independent': False}]]
+        if strategy_name == 'gp':
+            # Default values
+            try:
+                strategy_params['kernels']
+            except KeyError:
+                strategy_params['kernels'] = [['GPy.kern.Matern52', {'ARD': True}, {'independent': False}]]
 
-        # Check entries are of correct form
-        kernels = strategy_params['kernels']
-        if not isinstance(kernels, list):
-            raise RuntimeError('Must provide enumeration of Kernels')
-        for kernel in kernels:
-            if not isinstance(kernel, list) or len(kernel) != 3:
-                raise RuntimeError('Each kernel must be list: [entry point, {kwargs}, {options}]')
+            # Check entries are of correct form
+            kernels = strategy_params['kernels']
+            if not isinstance(kernels, list):
+                raise RuntimeError('Must provide enumeration of Kernels')
+            for kernel in kernels:
+                if not isinstance(kernel, list) or len(kernel) != 3:
+                    raise RuntimeError('Each kernel must be list: [entry point, {kwargs}, {options}]')
 
         strat = init_subclass_by_name(BaseStrategy, strategy_name,
                                       strategy_params)

--- a/osprey/config.py
+++ b/osprey/config.py
@@ -42,12 +42,6 @@ from .trials import Trial, make_session
 from .subclass_factory import init_subclass_by_name
 from . import eval_scopes
 
-try:
-    import GPy
-except:
-    GPy = None
-    pass
-
 FIELDS = {
     'estimator':       ['pickle', 'eval', 'eval_scope', 'entry_point',
                         'params'],
@@ -274,25 +268,6 @@ class Config(object):
     def strategy(self):
         strategy_name = self.get_value('strategy/name')
         strategy_params = self.get_value('strategy/params', default={})
-
-        if strategy_name == 'gp':
-            # TODO there must be a better way to do conditional defaults.
-            # Default values
-            try:
-                strategy_params['kernels']
-            except KeyError:
-                strategy_params['kernels'] = [{'name': 'GPy.kern.Matern52',
-                                               'params': {'ARD': True},
-                                               'options': {'independent': False}}]
-            # Check entries are of correct form
-            kernels = strategy_params['kernels']
-            if not isinstance(kernels, list):
-                raise RuntimeError('Must provide enumeration of kernels')
-            for kernel in kernels:
-                if sorted(list(kernel.keys())) != ['name', 'options', 'params']:
-                    raise RuntimeError(
-                        'strategy/params/kernels must contain keys: "name", "options", "params"')
-
         strat = init_subclass_by_name(BaseStrategy, strategy_name,
                                       strategy_params)
         return strat

--- a/osprey/data/sklearn_skeleton_config.yaml
+++ b/osprey/data/sklearn_skeleton_config.yaml
@@ -5,6 +5,9 @@ strategy:
   name: gp
   params:
     seeds: 5
+    kernels:
+      - { name : GPy.kern.Matern52, params : {ARD : True}, options : {independent : False} }
+      - { name : GPy.kern.White, params : {}, options: {independent : False} }
 
 search_space:
   C:

--- a/osprey/strategies.py
+++ b/osprey/strategies.py
@@ -19,6 +19,9 @@ try:
     from GPy.util.linalg import tdot
     from GPy.models import GPRegression
     from scipy.optimize import minimize
+    # If the GPy modules fail we won't do this unnecessarily.
+    from .entry_point import load_entry_point
+    KERNEL_BASE_CLASS = kern.src.kern.Kern
 except:
     # GPy is optional, but required for gp
     GPRegression = kern = minimize = None
@@ -198,7 +201,7 @@ class HyperoptTPE(BaseStrategy):
 class GP(BaseStrategy):
     short_name = 'gp'
 
-    def __init__(self, kernels=None, seed=None, seeds=1, max_feval=5E4, max_iter=1E5):
+    def __init__(self, kernels, seed=None, seeds=1, max_feval=5E4, max_iter=1E5):
         self.seed = seed
         self.seeds = seeds
         self.max_feval = max_feval
@@ -209,21 +212,22 @@ class GP(BaseStrategy):
         self._kerns = None
         self._kernf = None
         self._kernb = None
+        print(kernels)
 
     def _create_kernel(self, V):
 
         # # Turn into entry points.
-        # # TODO check if Import checking for GPy has been done.
+        # # TODO use eval to allow user to specify variables for kernels (e.g. V) in config file.
         # kernels = []
         # for kernel in kernels:
         #     kernel_ep = load_entry_point(kernel[0], 'strategy/params/kernels')
-        #     if issubclass(kernel_ep, GPy.kern.src.kern.Kern):
+        #     if issubclass(kernel_ep, KERNEL_BASE_CLASS):
+        #
         #
         #     if not isinstance(kernel)
         #         raise RuntimeError('strategy/params/kernel must load a'
         #                            'GPy derived Kernel')
-        #
-        # strategy_params['kernels'] = kernels
+
 
         # all_kernels = []
         # for kernel in self._kernels:

--- a/osprey/strategies.py
+++ b/osprey/strategies.py
@@ -201,7 +201,10 @@ class HyperoptTPE(BaseStrategy):
 class GP(BaseStrategy):
     short_name = 'gp'
 
-    def __init__(self, kernels, seed=None, seeds=1, max_feval=5E4, max_iter=1E5):
+    def __init__(self, kernels=[{'name': 'GPy.kern.Matern52',
+                                'params': {'ARD': True},
+                                'options': {'independent': False}}],
+                 seed=None, seeds=1, max_feval=5E4, max_iter=1E5):
         self.seed = seed
         self.seeds = seeds
         self.max_feval = max_feval
@@ -212,6 +215,15 @@ class GP(BaseStrategy):
         self._kerns = kernels
 
     def _create_kernel(self):
+        # Check kernels
+        kernels = self._kerns
+        if not isinstance(kernels, list):
+            raise RuntimeError('Must provide enumeration of kernels')
+        for kernel in kernels:
+            if sorted(list(kernel.keys())) != ['name', 'options', 'params']:
+                raise RuntimeError(
+                    'strategy/params/kernels must contain keys: "name", "options", "params"')
+
         # Turn into entry points.
         # TODO use eval to allow user to specify internal variables for kernels (e.g. V) in config file.
         kernels = []

--- a/osprey/strategies.py
+++ b/osprey/strategies.py
@@ -223,7 +223,7 @@ class GP(BaseStrategy):
             if issubclass(kernel_ep, KERNEL_BASE_CLASS):
                 if options['independent']:
                     #TODO Catch errors here?  Estimator entry points don't catch instantiation errors
-                    kernel = np.sum([kernel_ep(1, **params, active_dims=[i]) for i in range(self.n_dims)])
+                    kernel = np.sum([kernel_ep(1, active_dims=[i], **params) for i in range(self.n_dims)])
                 else:
                     kernel = kernel_ep(self.n_dims, **params)
             if not isinstance(kernel, KERNEL_BASE_CLASS):

--- a/osprey/strategies.py
+++ b/osprey/strategies.py
@@ -216,19 +216,16 @@ class GP(BaseStrategy):
         # TODO use eval to allow user to specify internal variables for kernels (e.g. V) in config file.
         kernels = []
         for kern in self._kerns:
-            try:
-                kwargs = kern['kwargs']
-                options = kern['options']
-                name = kern['name']
-            except KeyError as e:
-                raise RuntimeError(e.message)
-
+            params = kern['params']
+            options = kern['options']
+            name = kern['name']
             kernel_ep = load_entry_point(name, 'strategy/params/kernels')
             if issubclass(kernel_ep, KERNEL_BASE_CLASS):
                 if options['independent']:
-                    kernel = np.sum([kernel_ep(1, **kwargs, active_dims=[i]) for i in range(self.n_dims)])
+                    #TODO Catch errors here?  Estimator entry points don't catch instantiation errors
+                    kernel = np.sum([kernel_ep(1, **params, active_dims=[i]) for i in range(self.n_dims)])
                 else:
-                    kernel = kernel_ep(self.n_dims, **kwargs)
+                    kernel = kernel_ep(self.n_dims, **params)
             if not isinstance(kernel, KERNEL_BASE_CLASS):
                 raise RuntimeError('strategy/params/kernel must load a'
                                    'GPy derived Kernel')

--- a/osprey/strategies.py
+++ b/osprey/strategies.py
@@ -216,9 +216,13 @@ class GP(BaseStrategy):
         # TODO use eval to allow user to specify internal variables for kernels (e.g. V) in config file.
         kernels = []
         for kern in self._kerns:
-            kwargs = kern['kwargs']
-            options = kern['options']
-            name = kern['name']
+            try:
+                kwargs = kern['kwargs']
+                options = kern['options']
+                name = kern['name']
+            except KeyError as e:
+                raise RuntimeError(e.message)
+
             kernel_ep = load_entry_point(name, 'strategy/params/kernels')
             if issubclass(kernel_ep, KERNEL_BASE_CLASS):
                 if options['independent']:

--- a/osprey/strategies.py
+++ b/osprey/strategies.py
@@ -198,7 +198,7 @@ class HyperoptTPE(BaseStrategy):
 class GP(BaseStrategy):
     short_name = 'gp'
 
-    def __init__(self, independent=False, kernels=None, seed=None, seeds=1, max_feval=5E4, max_iter=1E5):
+    def __init__(self, kernels=None, seed=None, seeds=1, max_feval=5E4, max_iter=1E5):
         self.seed = seed
         self.seeds = seeds
         self.max_feval = max_feval
@@ -211,6 +211,30 @@ class GP(BaseStrategy):
         self._kernb = None
 
     def _create_kernel(self, V):
+
+        # # Turn into entry points.
+        # # TODO check if Import checking for GPy has been done.
+        # kernels = []
+        # for kernel in kernels:
+        #     kernel_ep = load_entry_point(kernel[0], 'strategy/params/kernels')
+        #     if issubclass(kernel_ep, GPy.kern.src.kern.Kern):
+        #
+        #     if not isinstance(kernel)
+        #         raise RuntimeError('strategy/params/kernel must load a'
+        #                            'GPy derived Kernel')
+        #
+        # strategy_params['kernels'] = kernels
+
+        # all_kernels = []
+        # for kernel in self._kernels:
+        #     if self._is_independent:
+        #         all_kernels.extend([kernel(1, ARD=True, active_dims=[i]) for i in range(self.n_dims)])
+        #     else:
+        #         all_kernels.extend(kernel(self.n_dims, ARD=True))
+        #     print(all_kernels)
+        # self.kernel = np.sum(all_kernels)
+        # print(self.kernel)
+
         self._kerns = [RBF(1, ARD=True, active_dims=[i])
                        for i in range(self.n_dims)]
         self._kernf = Fixed(self.n_dims, tdot(V))

--- a/osprey/strategies.py
+++ b/osprey/strategies.py
@@ -201,9 +201,7 @@ class HyperoptTPE(BaseStrategy):
 class GP(BaseStrategy):
     short_name = 'gp'
 
-    def __init__(self, kernels=[{'name': 'GPy.kern.Matern52',
-                                'params': {'ARD': True},
-                                'options': {'independent': False}}],
+    def __init__(self, kernels=None,
                  seed=None, seeds=1, max_feval=5E4, max_iter=1E5):
         self.seed = seed
         self.seeds = seeds
@@ -212,6 +210,9 @@ class GP(BaseStrategy):
         self.model = None
         self.n_dims = None
         self.kernel = None
+        if kernels is None:
+            kernels = [{'name': 'GPy.kern.Matern52', 'params': {'ARD': True},
+                        'options': {'independent': False}}]
         self._kerns = kernels
 
     def _create_kernel(self):
@@ -261,10 +262,6 @@ class GP(BaseStrategy):
             # TODO Could use options dict to specify what type of kernel to create when
             y = x.copy().reshape(-1, self.n_dims)
             s, v = self.model.predict(y)
-            if v < 0:
-                print('*** Negative variance: {} ***'.format(v))
-            elif v > 0:
-                print('*** Positive variance: {} ***'.format(v))
             return -(s+v).flatten()
 
         return minimize(z, init, bounds=self.n_dims*[(0., 1.)],

--- a/osprey/strategies.py
+++ b/osprey/strategies.py
@@ -198,7 +198,7 @@ class HyperoptTPE(BaseStrategy):
 class GP(BaseStrategy):
     short_name = 'gp'
 
-    def __init__(self, seed=None, seeds=1, max_feval=5E4, max_iter=1E5):
+    def __init__(self, independent=False, kernels=None, seed=None, seeds=1, max_feval=5E4, max_iter=1E5):
         self.seed = seed
         self.seeds = seeds
         self.max_feval = max_feval

--- a/osprey/strategies.py
+++ b/osprey/strategies.py
@@ -261,6 +261,10 @@ class GP(BaseStrategy):
             # TODO Could use options dict to specify what type of kernel to create when
             y = x.copy().reshape(-1, self.n_dims)
             s, v = self.model.predict(y)
+            if v < 0:
+                print('*** Negative variance: {} ***'.format(v))
+            elif v > 0:
+                print('*** Positive variance: {} ***'.format(v))
             return -(s+v).flatten()
 
         return minimize(z, init, bounds=self.n_dims*[(0., 1.)],

--- a/osprey/tests/test_strategies.py
+++ b/osprey/tests/test_strategies.py
@@ -102,7 +102,7 @@ def test_1():
 
     np.testing.assert_array_equal(ref, ours)
 
-
+# TODO this error message needs changing.
 @skipif('GPy' not in sys.modules, 'this test requires hyperopt')
 def test_gp():
     searchspace = SearchSpace()
@@ -113,7 +113,11 @@ def test_gp():
 
     history = [(searchspace.rvs(), np.random.random(), 'SUCCEEDED')
                for _ in range(4)]
-    params = GP().suggest(history, searchspace)
+
+    kerns = [{'name': 'GPy.kern.Matern52', 'params': {'ARD': True},
+             'options': {'independent': False}}]
+
+    params = GP(kernels=kerns).suggest(history, searchspace)
     for k, v in iteritems(params):
         assert k in searchspace.variables
         if isinstance(searchspace[k], EnumVariable):

--- a/osprey/tests/test_strategies.py
+++ b/osprey/tests/test_strategies.py
@@ -114,10 +114,7 @@ def test_gp():
     history = [(searchspace.rvs(), np.random.random(), 'SUCCEEDED')
                for _ in range(4)]
 
-    kerns = [{'name': 'GPy.kern.Matern52', 'params': {'ARD': True},
-             'options': {'independent': False}}]
-
-    params = GP(kernels=kerns).suggest(history, searchspace)
+    params = GP().suggest(history, searchspace)
     for k, v in iteritems(params):
         assert k in searchspace.variables
         if isinstance(searchspace[k], EnumVariable):


### PR DESCRIPTION
 - [x] Implement feature / fix bug
 - [x] Add tests
 - [x] Update changelog

Added the ability to add an arbitrary number of GPy kernels to the gp strategy.
```
    kernels:
      - { name : GPy.kern.Matern52, params : {ARD : True}, options : {independent : False} }
      - { name : GPy.kern.White, params : {}, options: {independent : False} }

```
1. The `params` dictionary specifies all the keyword arguments to be supplied in the kernel's instantiation. 

1. The `options` dictionary is left as something that controls other options on how the kernel is instantiated.  At the moment only `independent` is coded for which controls whether the kernel acts on each dimension independently (`kern = np.sum([kernel(1, active_dims=[i]) for i in range(self.n_dims)]`) or jointly (`kern = kernel(self.n_dims)`). 

1. Kernels listed here are summed (not multiplied).  

1. Kernels can't accept arguments from internal data structures as in the current version e.g.
```
        self._kernf = Fixed(self.n_dims, tdot(V))
```
but this could be easily changed by a list of variables specified to be passed to the kernel instantiation via a call to `eval()`. 

This is good enough for my purposes at the moment, but if you like what I've done and want me to make other changes let me know I'd be happy to work further on this. 









