### PR TITLE
New gp acquisition functions

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -19,7 +19,8 @@ New Features
 + Added ``max_param_suggestion_retries`` entry to the config file. This limits the number of times that
   ``strategy.suggest`` is called when attempting to produce a trial with a set of params not previously
   tested in the history. 
-
++ Added the ability to specify three different acquisition functions for the gaussian processes strategy: expected
+improvement `ei`, upper confidence bound, `ucb` and the original Osprey function (the default), `osprey`.
 
 Bug Fixes
 ~~~~~~~~~

--- a/osprey/data/sklearn_skeleton_config.yaml
+++ b/osprey/data/sklearn_skeleton_config.yaml
@@ -5,6 +5,7 @@ strategy:
   name: gp
   params:
     seeds: 5
+    acquisition: { name : ei, params : {}}
 
 search_space:
   C:

--- a/osprey/strategies.py
+++ b/osprey/strategies.py
@@ -202,7 +202,7 @@ class HyperoptTPE(BaseStrategy):
 class GP(BaseStrategy):
     short_name = 'gp'
 
-    def __init__(self, acquisition={'name':'osprey', 'params': {}}, seed=None, seeds=1, max_feval=5E4, max_iter=1E5):
+    def __init__(self, acquisition=None, seed=None, seeds=1, max_feval=5E4, max_iter=1E5):
         self.seed = seed
         self.seeds = seeds
         self.max_feval = max_feval
@@ -213,6 +213,8 @@ class GP(BaseStrategy):
         self._kerns = None
         self._kernf = None
         self._kernb = None
+        if acquisition is None:
+            acquisition = {'name': 'osprey', 'params': {}}
         self.acquisition_function = acquisition
         self._acquisition_function = None
         self._set_acquisition()


### PR DESCRIPTION
 - [x] Implement feature / fix bug
 - [x] Add tests
 - [x] Update changelog

Added different acquisition functions: 
```
strategy:
  name: gp
  params:
    seeds: 5
    acquisition: { name : ei, params : {}}
```
`name` is the name of the acquisition function. `params` is any keyword parameters (e.g. `kappa` in the case of upper confidence bound)

1) `ei` the expected improvement ([eq 2](https://papers.nips.cc/paper/4522-practical-bayesian-optimization-of-machine-learning-algorithms.pdf)). Takes no additional parameters.
2) `ucb` - the upper confidence bound ([eq 3](https://papers.nips.cc/paper/4522-practical-bayesian-optimization-of-machine-learning-algorithms.pdf)). Takes parameter `kappa`.  
3) `osprey` - the original Osprey acquisition function. Takes no additional parameters. This is the default. 

As `ei` and `ucb` both rely on the standard deviation (via `np.sqrt(variance)`) of the model prediction, there is a error check to see whether the variance returned is `>0` (see [issue 228](https://github.com/msmbuilder/osprey/issues/228)).  Specifying `osprey` by-passes this error checking so that original functionality can be recovered. 

The `sklearn_skeleton` example has been updated to include this functionality. 

I've merged this and [PR 227](https://github.com/msmbuilder/osprey/pull/227) in another branch on my own repo [here](https://github.com/RobertArbon/osprey/tree/Development).  Not submitting this as a PR. 